### PR TITLE
Add apiClient for dio configuration, create model classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/lib/core/data/api_client.dart
+++ b/lib/core/data/api_client.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+
+class ApiClient {
+  final String baseUrl;
+
+  const ApiClient({required this.baseUrl});
+
+//
+  Dio get dio => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 60),
+          receiveTimeout: const Duration(seconds: 60),
+        ),
+      );
+}

--- a/lib/core/dependencies/registry.dart
+++ b/lib/core/dependencies/registry.dart
@@ -1,0 +1,9 @@
+import 'package:get_it/get_it.dart';
+import 'package:myflix/core/data/api_client.dart';
+
+//
+void registerdependencies({String baseUrl = ''}) {
+  final apiClient = ApiClient(baseUrl: baseUrl);
+
+  GetIt.I.registerLazySingleton<ApiClient>(() => apiClient);
+}

--- a/lib/core/models/movie_model.dart
+++ b/lib/core/models/movie_model.dart
@@ -1,0 +1,24 @@
+class Movie {
+  final String movieTitle, posterUrl, backdropUrl, overview;
+  final String year;
+  final double averageRating;
+
+  const Movie({
+    required this.movieTitle,
+    required this.posterUrl,
+    required this.backdropUrl,
+    required this.overview,
+    required this.year,
+    required this.averageRating,
+  });
+
+  factory Movie.fromJson(Map<String, dynamic> data) {
+    return Movie(
+        movieTitle: data['original_title'],
+        posterUrl: data['poster_path'],
+        backdropUrl: data['backdrop_path'],
+        overview: data['overview'],
+        year: data['release_date'],
+        averageRating: data['vote_average']);
+  }
+}

--- a/lib/core/models/result_model.dart
+++ b/lib/core/models/result_model.dart
@@ -1,0 +1,21 @@
+import 'package:myflix/core/models/movie_model.dart';
+
+class Result {
+  final int pageNumber;
+  final List<Movie> movieResults;
+
+  const Result({
+    required this.pageNumber,
+    required this.movieResults,
+  });
+
+  factory Result.fromJson(Map<String, dynamic> data) {
+    final list = data['results'] as List<dynamic>;
+    final movies = list
+        .map(
+          (e) => Movie.fromJson(e),
+        )
+        .toList();
+    return Result(pageNumber: data['page'], movieResults: movies);
+  }
+}

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -1,0 +1,27 @@
+import 'dart:developer' as dev;
+
+AppLogger getLogger(Object scope) => _Logger(scope.toString());
+bool _showLogs = false;
+
+abstract class AppLogger {
+  AppLogger._();
+
+//
+  static void configure({required bool showLogs}) {
+    _showLogs = showLogs;
+  }
+
+  void log(Object? e) {}
+}
+
+class _Logger implements AppLogger {
+  final String scope;
+  _Logger(this.scope);
+
+  @override
+  void log(Object? e) {
+    if (_showLogs) {
+      dev.log('$scope: $e');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:myflix/core/dependencies/registry.dart';
 import 'package:myflix/core/routes.dart';
+import 'package:myflix/core/utils/logger.dart';
 import 'package:myflix/features/details/presentation/view/movie_details_page.dart';
 import 'package:myflix/views/index_page.dart';
 
 void main() {
+  AppLogger.configure(showLogs: kDebugMode);
+  registerdependencies(baseUrl: const String.fromEnvironment('BASE_URL'));
   runApp(const MyApp());
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "0978e9a3e45305a80a7210dbeaf79d6ee8bee33f70c8e542dc654c952070217f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.2+1"
   fake_async:
     dependency: transitive
     description:
@@ -75,6 +83,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      sha256: e6017ce7fdeaf218dc51a100344d8cb70134b80e28b760f8bb23c242437bafd7
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.6.7"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   js:
     dependency: transitive
     description:
@@ -176,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  dio: ^5.4.2+1
+  get_it: ^7.6.7
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR does the following:

- Adds ApiClient which configures and exposes Dio for network requests
- Adds dependency registry for registering dependencies using Get It
- Adds Movie model class and result model class
- Adds logger
